### PR TITLE
Debug referrer in /google endpoint

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -9,6 +9,8 @@ module.exports = ({ apiKey }) => {
   const app = express()
 
   const handler = asyncJsonHandler(async (req, res, next) => {
+    // yes, HTTP misspells it as "referer" :facepalm:
+    debug('request:', req.path, '← referrer:', req.header('referer'))
     // combine the query string and path params into a single query object
     const query = Object.assign({}, req.query, req.params)
     return getTranslations(query)


### PR DESCRIPTION
This seems to be the easiest way to understand where the trickle of requests to the deprecated Heroku service are coming from. 🤷‍♂️ 

![image](https://user-images.githubusercontent.com/113896/91606161-6faf2600-e926-11ea-83f1-81d1ac97c8a6.png)
