### PR TITLE
Add Phrase project link API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # i18n-microservice-js
-This is a microservice for transforming Google Spreadsheets into [i18next]
-translation data. There is currently only one endpoint:
+This is an API for transforming Phrase projects and Google Spreadsheets into
+[i18next] translation data. The endpoints are:
+
+## `/phrase/:projectId`
+Returns **un-cached** translations for the given Phrase project.
+
+## `/phrase/:projectId@version`
+Returns **permanently cached** translations for the given Phrase project for
+each unique value of `:version`.
+
+## `/phrase/:projectId/link`
+Redirects to the dashboard for the given Phrase project.
 
 ## `/google/:sheetId`
 

--- a/lib/phrase.js
+++ b/lib/phrase.js
@@ -1,24 +1,35 @@
 const fetch = require('node-fetch')
 const cache = require('./cache')
 const cors = require('cors')
+const log = require('./log').scope('phrase')
 const { Router } = require('express')
-const { Configuration, TranslationsApi } = require('phrase-js')
+const { Configuration, ProjectsApi, TranslationsApi } = require('phrase-js')
 const { asyncJsonHandler, isCacheError, localize } = require('./handlers')
 const { success, debug, warn } = require('./log').scope('phrase')
 
 const EXPIRES_NEVER = 4294967295
 
-const { PHRASE_ACCESS_TOKEN } = process.env
+const {
+  PHRASE_ACCESS_TOKEN,
+  PHRASE_ORG_SLUG = 'city-county-of-san-francisco'
+} = process.env
+
+if (!PHRASE_ACCESS_TOKEN) {
+  log.error('PHRASE_ACCESS_TOKEN is not set!')
+}
+
+if (!global.FormData) {
+  // Phrase needs this because it thinks it's running in a browser
+  global.FormData = require('formdata-node')
+}
 
 const config = new Configuration({
   apiKey: `token ${PHRASE_ACCESS_TOKEN}`,
   fetchApi: fetch
 })
 
-// Phrase needs this because it thinks it's running in a browser
-global.FormData = require('formdata-node')
-
 module.exports = Router()
+  .get('/:projectId/link', projectLink)
   .use('/', localize(req => req.query))
   .use('/:projectId', localize(req => req.params))
   .use('/:projectId@:version', localize(req => req.params))
@@ -95,4 +106,20 @@ function paginate (initialParams, request) {
   })
   debug('paginating:', initialParams, '=>', params)
   return next()
+}
+
+async function projectLink (req, res) {
+  const id = req.params.projectId
+  const api = new ProjectsApi(config)
+  const project = await api.projectShow({ id })
+    .catch(error => {
+      log.error('unable to load Phrase project "%s":', id, error)
+      return null
+    })
+  if (project) {
+    const url = `https://app.phrase.com/accounts/${PHRASE_ORG_SLUG}/projects/${project.slug}/dashboard`
+    return res.redirect(url)
+  } else {
+    return res.status(404).send('No such project')
+  }
 }

--- a/lib/phrase.js
+++ b/lib/phrase.js
@@ -29,9 +29,9 @@ const config = new Configuration({
 })
 
 module.exports = Router()
-  .get('/:projectId/link', projectLink)
   .use('/', localize(req => req.query))
   .use('/:projectId', localize(req => req.params))
+  .get('/:projectId/link', projectLink)
   .use('/:projectId@:version', localize(req => req.params))
   .use(
     cors(),

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js",
+    "develop": "nodemon server.js",
     "lint": "eslint *.js lib __tests__",
     "test": "jest --detectOpenHandles --forceExit"
   },


### PR DESCRIPTION
We need an API endpoint to create and redirect to the Phrase URL for a project with the given ID, since that's the only piece of identifying information that we require for linking a form.io form to Phrase. Here's the deal:

```
GET /phrase/:projectId/link
```

loads the Phrase project with the given `projectId` and, if it's found, redirects to the URL with its "slug":

```
https://app.phrase.com/accounts/city-county-of-san-francisco/projects/{slug}/dashboard
```

You can see in the deployment for this PR that [`/phrase/d7b0453eda36cb21a1b1471a0cd20714/link`](https://translate-sfgov-pr-13.herokuapp.com/phrase/d7b0453eda36cb21a1b1471a0cd20714/link) redirects to [the vaccination-sites project](https://app.phrase.com/accounts/city-county-of-san-francisco/projects/vaccination-sites/dashboard).