### PR TITLE
Fix Google API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
       - run: npm test
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          PHRASE_ACCESS_TOKEN: ${{ secrets.PHRASE_ACCESS_TOKEN }}

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const supertest = require('supertest')
 
 const app = require('../server')

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -1,0 +1,68 @@
+const supertest = require('supertest')
+
+const app = require('../server')
+
+describe('app URL tests', () => {
+  describe('phrase', () => {
+    const PROJECT_ID = 'ff36e9439ea05e3d16ccbd254125135f'
+    const VERSION = '1.0.0'
+    const canonicalURL = `/api/phrase?projectId=${PROJECT_ID}&version=${VERSION}`
+    const translations = expect.objectContaining({
+      en: expect.objectContaining({
+        cancel: 'Cancel'
+      })
+    })
+
+    it('serves up known Phrase translations from /api/phrase?{projectId,version}', () => {
+      return supertest(app)
+        .get(canonicalURL)
+        .expect(200)
+        .expect('content-type', /json/)
+        .then(({ body }) => {
+          expect(body).toEqual({
+            status: 'success',
+            data: translations
+          })
+        })
+    })
+
+    it('redirects from /phrase/:projectId@:version', () => {
+      return supertest(app)
+        .get(`/phrase/${PROJECT_ID}@${VERSION}`)
+        .expect(302)
+        .expect('location', canonicalURL)
+    })
+  })
+
+  describe('google sheets', () => {
+    const GOOGLE_SHEET_ID = '1hb5bC01hS7SRW8Wc7woYY7uji_M0CWTlLWtqyNiziSQ'
+    const VERSION = '1.0.0'
+    const canonicalURL = `/api/google?sheetId=${GOOGLE_SHEET_ID}&version=${VERSION}`
+
+    it('serves up known Google Sheets translations', () => {
+      jest.setTimeout(15000)
+
+      return supertest(app)
+        .get(canonicalURL)
+        .expect(200)
+        .expect('content-type', /json/)
+        .then(({ body }) => {
+          expect(body).toEqual({
+            status: 'success',
+            data: expect.objectContaining({
+              en: expect.objectContaining({
+                'page0.title': "Apply for help paying for your storefront's COVID-19 safety measures"
+              })
+            })
+          })
+        })
+    })
+
+    it('redirects to the canonical URL from /google/:sheetId@:version', () => {
+      return supertest(app)
+        .get(`/google/${GOOGLE_SHEET_ID}@${VERSION}`)
+        .expect(302)
+        .expect('location', canonicalURL)
+    })
+  })
+})

--- a/__tests__/phrase.js
+++ b/__tests__/phrase.js
@@ -1,8 +1,9 @@
+/* eslint-env jest */
 const express = require('express')
 const supertest = require('supertest')
 const memjsCacheMiddleware = require('express-memjs-cache')
 const cache = require('../lib/cache')
-const { Configuration, TranslationsApi } = require('phrase-js')
+const { TranslationsApi } = require('phrase-js')
 
 jest.mock('phrase-js')
 jest.mock('../lib/cache')

--- a/lib/google.js
+++ b/lib/google.js
@@ -12,16 +12,22 @@ if (!GOOGLE_API_KEY) {
 }
 
 module.exports = Router()
+  .use((req, res, next) => {
+    Object.assign(res.locals, req.params, req.query)
+    next()
+  })
   .use(cache({
     logger: require('./log').scope('cache'),
     getCacheKey (req, res) {
-      const { sheetId, version } = { ...req.params, ...req.query }
+      const { sheetId, version } = res.locals
       return version ? `google:${sheetId}@${version}` : null
     },
     isError (req, res, { body }) {
       try {
         const parsed = JSON.parse(body)
-        return parsed.status === 'error'
+        if (parsed.status === 'error') {
+          return true
+        }
       } catch (error) {
         warn('unable to parse body as JSON:', body)
         return true
@@ -30,7 +36,7 @@ module.exports = Router()
     }
   }))
   .get('/', publicVersionedJson((req, res) => {
-    return getTranslations(req.query)
+    return getTranslations(res.locals)
   }))
 
 async function getTranslations (params) {
@@ -80,10 +86,6 @@ async function getTranslations (params) {
 async function loadSheet (sheetId) {
   // spreadsheet key is the long id in the sheets URL
   const doc = new GoogleSpreadsheet(sheetId)
-  if (!GOOGLE_API_KEY) {
-    throw new Error('GOOGLE_API_KEY is not set')
-  }
-
   await doc.useApiKey(GOOGLE_API_KEY)
 
   try {

--- a/lib/google.js
+++ b/lib/google.js
@@ -7,20 +7,35 @@ const { success, debug, warn } = require('./log').scope('google')
 
 const { GOOGLE_API_KEY } = process.env
 
+if (!GOOGLE_API_KEY) {
+  warn('GOOGLE_API_KEY is not set!')
+}
+
 module.exports = Router()
   .use(cache({
     logger: require('./log').scope('cache'),
     getCacheKey (req, res) {
       const { sheetId, version } = { ...req.params, ...req.query }
       return version ? `google:${sheetId}@${version}` : null
+    },
+    isError (req, res, { body }) {
+      try {
+        const parsed = JSON.parse(body)
+        return parsed.status === 'error'
+      } catch (error) {
+        warn('unable to parse body as JSON:', body)
+        return true
+      }
+      return res.statusCode >= 400
     }
   }))
   .get('/', publicVersionedJson((req, res) => {
-    return getTranslations(req.params)
+    return getTranslations(req.query)
   }))
 
 async function getTranslations (params) {
   const { sheetId, sheet } = params
+  debug('sheetId:', sheetId)
   const doc = await loadSheet(sheetId)
 
   const data = {}
@@ -65,7 +80,11 @@ async function getTranslations (params) {
 async function loadSheet (sheetId) {
   // spreadsheet key is the long id in the sheets URL
   const doc = new GoogleSpreadsheet(sheetId)
-  doc.useApiKey(GOOGLE_API_KEY)
+  if (!GOOGLE_API_KEY) {
+    throw new Error('GOOGLE_API_KEY is not set')
+  }
+
+  await doc.useApiKey(GOOGLE_API_KEY)
 
   try {
     await doc.loadInfo() // loads document properties and worksheets
@@ -94,7 +113,8 @@ function trim (val) {
 
 class GoogleAPIError {
   constructor (error, messagePrefix = '') {
-    const { message, code = 500, status } = error.response.data.error
+    // console.warn('Google API error:', error.response)
+    const { message, code = 500, status } = error.response
     this.data = {
       message: message ? `${messagePrefix}: ${message}` : messagePrefix,
       code: code,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^4.17.1",
         "express-memjs-cache": "^0.0.0-e7d02a9",
         "formdata-node": "^2.2.1",
-        "google-spreadsheet": "^3.0.11",
+        "google-spreadsheet": "^3.1.15",
         "i18next": "^19.4.2",
         "node-cache": "^5.1.0",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "lint": "eslint *.js lib",
-    "test": "jest"
+    "lint": "eslint *.js lib __tests__",
+    "test": "jest --detectOpenHandles"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "^4.17.1",
     "express-memjs-cache": "^0.0.0-e7d02a9",
     "formdata-node": "^2.2.1",
-    "google-spreadsheet": "^3.0.11",
+    "google-spreadsheet": "^3.1.15",
     "i18next": "^19.4.2",
     "node-cache": "^5.1.0",
     "node-fetch": "^2.6.0",

--- a/server.js
+++ b/server.js
@@ -14,7 +14,11 @@ const app = express()
   .use('/api/phrase', phrase)
   .use(redirects)
 
-const server = app.listen(PORT, () => {
-  const { address, port } = server.address()
-  console.log('server listening at %s:%s', address === '::' ? 'localhost' : address, port)
-})
+if (module.parent) {
+  module.exports = app
+} else {
+  const server = app.listen(PORT, () => {
+    const { address, port } = server.address()
+    console.log('server listening at %s:%s', address === '::' ? 'localhost' : address, port)
+  })
+}


### PR DESCRIPTION
While rounding out the integration tests I discovered that the Google API wasn't working. This PR fixes it, and adds integration tests for the URLs that we care about (including redirects from `/{phrase,google}/:id@:version`).