### PR TITLE
Log less in production

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,9 +1,13 @@
 const { Signale } = require('signale')
+const { NODE_ENV } = process.env
 
 module.exports = new Signale({
   displayDate: true,
   displayTimestamp: true,
-  disabled: process.env.NODE_ENV === 'test',
+  // disable logging entirely in tests
+  disabled: NODE_ENV === 'test',
+  // don't log all messages in production
+  logLevel: NODE_ENV === 'production' ? 'warn' : 'info',
   types: {
     debug: {
       badge: '·',


### PR DESCRIPTION
To reduce the noise of our Papertrail logs 😁 

* Logging is still disabled entirely when `NODE_ENV=test`
* I've set `logLevel: 'warn'` in production, which should exclude `info`, `debug`, and timer messages